### PR TITLE
Add workflow and scraping automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# ClipKitAi agent – sample environment file
+PAYHIP_TOKEN=
+HUGGINGFACE_TOKEN=
+REDIS_URL=redis://localhost:6379
+REDIS_REST_TOKEN=
+SLACK_WEBHOOK_URL=

--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -1,0 +1,50 @@
+name: ClipKitAi nightly run
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"   # 05:00\u00a0UTC daily
+
+concurrency:
+  group: agent-run
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      redis:
+        image: redis
+        ports: ["6379:6379"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Scrape keywords
+        run: python scripts/scrape_keywords.py
+
+      - name: Generate images
+        run: python scripts/generate_images.py
+
+      - name: Bundle & upload
+        run: python scripts/bundle_and_upload.py
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+            -d "{\"text\":\"ClipKitAi run failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            $SLACK_WEBHOOK_URL
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+assets/
+.env
+
+# End of file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+feedparser
+redis
+python-dotenv
+pillow

--- a/scripts/bundle_and_upload.py
+++ b/scripts/bundle_and_upload.py
@@ -1,0 +1,42 @@
+"""Zip each generated pack and upload to Payhip."""
+import os, pathlib, zipfile, requests, time
+from dotenv import load_dotenv
+
+load_dotenv()
+
+PAYHIP_TOKEN = os.getenv("PAYHIP_TOKEN")
+PAYHIP_API = "https://payhip.com/api/v2/products"
+HEADERS = {"Authorization": f"Bearer {PAYHIP_TOKEN}"}
+
+ASSET_ROOT = pathlib.Path("assets")
+
+def make_zip(folder: pathlib.Path) -> pathlib.Path:
+    zip_path = folder.with_suffix(".zip")
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for img in folder.glob("*.png"):
+            zf.write(img, img.name)
+        zf.writestr("license.txt", "Royalty-free for personal and commercial use.")
+    return zip_path
+
+def upload(zip_path: pathlib.Path, title: str, price_cents: int = 300) -> str:
+    data = {
+        "product[price]": str(price_cents),
+        "product[title]": title,
+    }
+    files = {"file": zip_path.open("rb")}
+    resp = requests.post(PAYHIP_API, headers=HEADERS, data=data, files=files)
+    if resp.status_code == 429:
+        time.sleep(5)
+        return upload(zip_path, title, price_cents)
+    resp.raise_for_status()
+    return resp.json()["permalink"]
+
+def main() -> None:
+    for pack_dir in ASSET_ROOT.iterdir():
+        if pack_dir.is_dir():
+            zip_path = make_zip(pack_dir)
+            permalink = upload(zip_path, pack_dir.name.replace("_", " ").title())
+            print("Uploaded →", permalink)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_images.py
+++ b/scripts/generate_images.py
@@ -1,0 +1,51 @@
+"""Generate 5 PNGs (2048×2048) for one keyword using HuggingFace SDXL."""
+import os, time, pathlib, requests
+from io import BytesIO
+from PIL import Image
+import redis
+from dotenv import load_dotenv
+
+load_dotenv()
+
+HF_TOKEN = os.getenv("HUGGINGFACE_TOKEN")
+HF_ENDPOINT = "https://api-inference.huggingface.co/models/stabilityai/sdxl-base"
+HEADERS = {"Authorization": f"Bearer {HF_TOKEN}"}
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+r = redis.from_url(REDIS_URL, decode_responses=True)
+
+ASSET_ROOT = pathlib.Path("assets")
+ASSET_ROOT.mkdir(exist_ok=True)
+
+def pop_keyword() -> str | None:
+    res = r.zpopmin("ckai:keywords", 1)
+    return res[0][0] if res else None
+
+def slugify(text: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in text).lower()[:40]
+
+def generate_image(prompt: str) -> bytes:
+    resp = requests.post(HF_ENDPOINT, headers=HEADERS, json={"inputs": prompt})
+    resp.raise_for_status()
+    return resp.content
+
+def main() -> None:
+    kw = pop_keyword()
+    if not kw:
+        print("No keywords left in Redis.")
+        return
+
+    slug = slugify(kw)
+    out_dir = ASSET_ROOT / slug
+    out_dir.mkdir(exist_ok=True)
+
+    for i in range(5):
+        img_bytes = generate_image(kw)
+        img = Image.open(BytesIO(img_bytes))
+        img.save(out_dir / f"{slug}_{i+1}.png")
+        time.sleep(1)  # HuggingFace rate‑limit buffer
+
+    print(f"Generated pack '{slug}' → {out_dir}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scrape_keywords.py
+++ b/scripts/scrape_keywords.py
@@ -1,0 +1,37 @@
+"""Scrape trending keywords from Etsy and Creative Fabrica RSS feeds into Redis."""
+import os, time
+import feedparser
+import redis
+from dotenv import load_dotenv
+
+load_dotenv()
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+r = redis.from_url(REDIS_URL, decode_responses=True)
+
+RSS_FEEDS = {
+    "etsy": "https://www.etsy.com/trends/feed",
+    "cf": "https://www.creativefabrica.com/trending/feed/"
+}
+
+def fetch_keywords(limit: int = 200) -> list[str]:
+    """Return up to *limit* lower‑cased terms from both feeds."""
+    terms: set[str] = set()
+    for url in RSS_FEEDS.values():
+        feed = feedparser.parse(url)
+        for entry in feed.entries:
+            terms.add(entry.title.lower())
+    return list(terms)[:limit]
+
+def push_keywords(keywords: list[str]) -> None:
+    """Insert keywords into a sorted‑set `ckai:keywords` with the current timestamp."""
+    now = int(time.time())
+    pipe = r.pipeline()
+    for kw in keywords:
+        pipe.zadd("ckai:keywords", {kw: now})
+    pipe.execute()
+
+if __name__ == "__main__":
+    kws = fetch_keywords()
+    push_keywords(kws)
+    print(f"Pushed {len(kws)} keywords to Redis.")


### PR DESCRIPTION
## Summary
- add Python dependencies
- create scripts to fetch keywords, generate images, and upload packs
- set up nightly GitHub Actions workflow
- provide env template and ignore local artifacts

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6873f32cb6a8832296af46d089ede5f5