### PR TITLE
Add Pinterest pin script & workflow step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ HUGGINGFACE_TOKEN=
 REDIS_URL=redis://localhost:6379
 REDIS_REST_TOKEN=
 SLACK_WEBHOOK_URL=
+PIN_KEY=
+PIN_BOARD_ID=   # optional; leave blank to pin to default board

--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -15,6 +15,8 @@ env:
   REDIS_URL:         ${{ secrets.REDIS_URL || 'redis://localhost:6379' }}
   REDIS_REST_TOKEN:  ${{ secrets.REDIS_REST_TOKEN }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  PIN_KEY:       ${{ secrets.PIN_KEY }}
+  PIN_BOARD_ID:  ${{ secrets.PIN_BOARD_ID }}
 
 jobs:
   run:
@@ -46,6 +48,10 @@ jobs:
 
       - name: Bundle & upload
         run: python scripts/bundle_and_upload.py
+
+      - name: Pin newest pack on Pinterest
+        run: python scripts/pin_latest.py
+        if: env.PIN_KEY != ''
 
       - name: Notify Slack on failure
         if: failure()

--- a/scripts/pin_latest.py
+++ b/scripts/pin_latest.py
@@ -1,0 +1,37 @@
+"""Pin the newest generated thumbnail to Pinterest via API v5."""
+import os, pathlib, random, requests, sys
+from dotenv import load_dotenv
+
+load_dotenv()
+PIN_TOKEN = os.getenv("PIN_KEY")                # required
+BOARD_ID  = os.getenv("PIN_BOARD_ID", "")       # optional specific board
+ASSETS    = pathlib.Path("assets")
+API_URL   = "https://api.pinterest.com/v5/pins"
+HDRS      = {"Authorization": f"Bearer {PIN_TOKEN}"}
+
+if not PIN_TOKEN:
+    sys.exit("PIN_KEY is not set; skipping pin step.")
+
+def newest_thumb() -> pathlib.Path:
+    packs = sorted(ASSETS.glob("*"), key=lambda p: p.stat().st_mtime, reverse=True)
+    for pack in packs:
+        thumbs = list(pack.glob("*.png"))
+        if thumbs:
+            return random.choice(thumbs)
+    raise FileNotFoundError("No thumbnails found under assets/.")
+
+def post_pin(img: pathlib.Path):
+    data = {"title": img.parent.name.replace("_", " ").title()}
+    if BOARD_ID:
+        data["board_id"] = BOARD_ID
+    files = {"media": img.open("rb")}
+    r = requests.post(API_URL, headers=HDRS, data=data, files=files, timeout=60)
+    r.raise_for_status()
+    print("📌  Pinned:", r.json().get("id"))
+
+if __name__ == "__main__":
+    try:
+        post_pin(newest_thumb())
+    except Exception as e:
+        print("Pinterest pin failed:", e, file=sys.stderr)
+        sys.exit(0)  # don\u2019t break the workflow


### PR DESCRIPTION
## Summary
- add `pin_latest.py` script to post thumbnails to Pinterest
- update GitHub Actions workflow to run the new script
- expand `.env.example` with Pinterest variables

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687590f7a3fc83229a194ca6744cf005