### PR TITLE
Rewrite keyword scraper

### DIFF
--- a/.github/workflows/auto.yml
+++ b/.github/workflows/auto.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Install deps
         run: pip install -r requirements.txt
 
+      # - name: Echo token masks (debug)
+      #   run: |
+      #     echo "HF=${HUGGINGFACE_TOKEN:-none}"
+      #     echo "PAYHIP=${PAYHIP_TOKEN:-none}"
+      #     echo "PIN=${PIN_KEY:-none}"
+
       - name: Scrape keywords
         run: python scripts/scrape_keywords.py
 

--- a/scripts/scrape_keywords.py
+++ b/scripts/scrape_keywords.py
@@ -1,5 +1,7 @@
-"""Scrape trending keywords from Etsy and Creative Fabrica RSS feeds into Redis."""
-import os, time
+"""Fetch trending keyword titles from RSS feeds and push them to Redis."""
+import os
+import time
+import requests
 import feedparser
 import redis
 from dotenv import load_dotenv
@@ -11,25 +13,59 @@ r = redis.from_url(REDIS_URL, decode_responses=True)
 
 RSS_FEEDS = {
     "etsy": "https://www.etsy.com/trends/feed",
-    "cf": "https://www.creativefabrica.com/trending/feed/"
+    "cf": "https://www.creativefabrica.com/trending/feed/",
 }
 
+UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/115.0 Safari/537.36"
+)
+
+FALLBACK = [
+    "kawaii icons",
+    "pastel clipart",
+    "rocket sticker",
+    "watercolor flower",
+    "minimal ui icons",
+]
+
+
 def fetch_keywords(limit: int = 200) -> list[str]:
-    """Return up to *limit* lower‑cased terms from both feeds."""
-    terms: set[str] = set()
+    """Return up to *limit* unique titles from all feeds."""
+    headers = {"User-Agent": UA}
+    seen: set[str] = set()
+    out: list[str] = []
     for url in RSS_FEEDS.values():
-        feed = feedparser.parse(url)
-        for entry in feed.entries:
-            terms.add(entry.title.lower())
-    return list(terms)[:limit]
+        try:
+            resp = requests.get(url, headers=headers, timeout=15)
+            resp.raise_for_status()
+        except Exception as e:
+            print(f"Failed to fetch {url}: {e}")
+            continue
+        feed = feedparser.parse(resp.text)
+        for entry in getattr(feed, "entries", []):
+            title = getattr(entry, "title", "").strip().lower()
+            if title and title not in seen:
+                seen.add(title)
+                out.append(title)
+                if len(out) >= limit:
+                    break
+        if len(out) >= limit:
+            break
+    if not out:
+        out = FALLBACK.copy()
+    return out[:limit]
+
 
 def push_keywords(keywords: list[str]) -> None:
-    """Insert keywords into a sorted‑set `ckai:keywords` with the current timestamp."""
+    """Push terms into Redis sorted set `ckai:keywords`."""
     now = int(time.time())
     pipe = r.pipeline()
     for kw in keywords:
         pipe.zadd("ckai:keywords", {kw: now})
     pipe.execute()
+
 
 if __name__ == "__main__":
     kws = fetch_keywords()


### PR DESCRIPTION
## Summary
- refactor `scrape_keywords.py` to use requests with a Chrome user-agent
- support fallback list when no results found
- expose commented out debug token print step in workflow

## Testing
- `python -m py_compile scripts/scrape_keywords.py`

------
https://chatgpt.com/codex/tasks/task_e_68769742d6188322a6977690995d3339